### PR TITLE
Add a more minimal panic message and update cortex-m

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ cortex-m = "0.6.0"
 default = []
 utf8 = []
 custom-panic-handler = []
+min-panic = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.2.1"
 readme = "README.md"
 
 [dependencies]
-cortex-m = "0.6.0"
+cortex-m = "0.7.2"
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,21 +73,21 @@
 //! ```
 //!
 //! ## Features
-//! 
+//!
 //! There are two optional features, `utf8` and `custom-panic-handler`.
-//! 
+//!
 //! ### utf8
-//! 
+//!
 //! This allows the panic message to be returned
 //! as a `&str` rather than `&[u8]`, for easier printing. As this requires the ability
 //! to validate the UTF-8 string (to ensure it wasn't truncated mid-character), it may
 //! increase code size usage, and is by default off.
-//! 
+//!
 //! ### custom-panic-handler
-//! 
+//!
 //! This disables the panic handler from this library so that any user can implement their own.
 //! To persist panic messages, the function `report_panic_info` is made available;
-//! 
+//!
 //! ```rust
 //! // My custom panic implementation
 //! #[panic_handler]
@@ -250,6 +250,14 @@ pub fn report_panic_info(info: &PanicInfo) {
 fn panic(info: &PanicInfo) -> ! {
     cortex_m::interrupt::disable();
 
+    #[cfg(feature = "min-panic")]
+    if let Some(location) = info.location() {
+        writeln!(Ram { offset: 0 }, "Panicked at {}", location).ok();
+    } else {
+        writeln!(Ram { offset: 0 }, "Panic occured!").ok();
+    }
+
+    #[cfg(not(feature = "min-panic"))]
     writeln!(Ram { offset: 0 }, "{}", info).ok();
 
     cortex_m::peripheral::SCB::sys_reset();


### PR DESCRIPTION
This PR adds a new feature called `min-panic`. This version of the panic message _only_ prints out the line number at which the panic occurred if it exists. If it does not exist, the only thing that's printed out is that a panic occured.

This feature may help in situations with very small size constraints, as it means that the most important part of the error (i.e. the line number) is printed first, instead of the panic message.

While they could be considered equally important, knowing the line number generally helps more than (part of) the panic message.

Also updates cortex-m to the latest version